### PR TITLE
Use the local binaries for node and npm

### DIFF
--- a/scripts/install-sdk.sh
+++ b/scripts/install-sdk.sh
@@ -99,8 +99,9 @@ installGlobalDeps() {
 }
 
 ############################################################################
-NPM=npm
-NODE=node
+C9_DIR=$HOME/.c9
+NPM=$C9_DIR/node/bin/npm
+NODE=$C9_DIR/node/bin/node
 
 updateCore || true
 


### PR DESCRIPTION
After running `installGlobalDeps` the expected path of `node` and `npm` is in the `.c9` folder, so either use the absolute path (this patch) or update the env PATH.