### PR TITLE
Added reload button to plugin manager

### DIFF
--- a/plugins/c9.ide.plugins/manager.js
+++ b/plugins/c9.ide.plugins/manager.js
@@ -347,9 +347,13 @@ define(function(require, exports, module) {
 
                     if (CORE[item.name] || item.parent.parent && item.parent.parent.isType == "core") {
                         btnUninstall.disable();
-                        btnReload.disable();
                     } else {
                         btnUninstall.enable();
+                    }
+
+                    if (item.isPackage || CORE[item.name] || item.parent.parent && item.parent.parent.isType == "core") {
+                        btnReload.disable();
+                    } else {
                         btnReload.enable();
                     }
 


### PR DESCRIPTION
The debug mode is nice if you want to actually debug, but applying a new iteration of your plugin with c9 spamming your dev-console with a million messages isn't really great.

Just reloading the plugin via the managers feels more natural and also works when you develop on core plugins (such as the plugin manager :)).

