### PR TITLE
Added a 'dontEscapeHTML' property in ace_tree to allow html when it i…

### DIFF
--- a/node_modules/ace_tree/lib/ace_tree/layer/cells.js
+++ b/node_modules/ace_tree/lib/ace_tree/layer/cells.js
@@ -109,9 +109,15 @@ var Cells = function(parentEl) {
         }
         if (columns) {
             for (var col = columns[0].type == "tree" ? 1 : 0; col < columns.length; col++) {
+                var column = columns[col];
+                var rowText = column.getText(datarow) + "";
+                if(!(column.dontEscapeHTML || node.dontEscapeHTML)){
+                    rowText = escapeHTML(rowText);
+                }
                 html.push("</span>" 
-                    + this.columnNode(datarow, columns[col], row)
-                    + escapeHTML(columns[col].getText(datarow) + ""));
+                    + this.columnNode(datarow, column, row)
+                    + rowText);
+                
             }
             html.push("</span>");
         }


### PR DESCRIPTION
…s specified. Discussion: https://groups.google.com/forum/#!topic/cloud9-sdk/k_O1-1HOb3s
If the property is not set, it works as before, if it is set, it will not escape html. Basic example:

	var datagrid = new Datagrid({
		container: div,
		enableCheckboxes: true,
		columns: [{
			caption: "Name",
			value: "label",
			width: "35%",
			type: "tree"
		}, {
			caption: "Description",
			dontEscapeHTML: true,
			getText: function(node) {
				return '<span style="color:red;">' + node.customValue + '</span>'
			},
			width: "65%"
		}]
	}, plugin);

It could also be set to a node as a property for more selective usage.