### PR TITLE
Added column.getHTML method to acetree

### DIFF
--- a/node_modules/ace_tree/lib/ace_tree/layer/cells.js
+++ b/node_modules/ace_tree/lib/ace_tree/layer/cells.js
@@ -109,9 +109,9 @@ var Cells = function(parentEl) {
         }
         if (columns) {
             for (var col = columns[0].type == "tree" ? 1 : 0; col < columns.length; col++) {
-                html.push("</span>" 
-                    + this.columnNode(datarow, columns[col], row)
-                    + escapeHTML(columns[col].getText(datarow) + ""));
+                var column = columns[col];
+                var rowStr = (column.getHTML) ? column.getHTML(datarow) : escapeHTML(column.getText(datarow) + "");
+                html.push("</span>" + this.columnNode(datarow, column, row) + rowStr);
             }
             html.push("</span>");
         }


### PR DESCRIPTION
@nightwing 
Tooltip issue does not exist with this implementation. 
[discussion](https://groups.google.com/forum/#!topic/cloud9-sdk/k_O1-1HOb3s)
Basic example:

	var datagrid = new Datagrid({
		container: div,
		enableCheckboxes: true,
		columns: [{
			caption: "Name",
			value: "label",
			width: "35%",
			type: "tree"
		}, {
			caption: "Description",
			dontEscapeHTML: true,
			getText: function(node) {
				return node.customValue;
			},
			getHTML: function(node){
				return '<span style="color:green;">' + node.customValue + '</span>';
			},
			width: "65%"
		}]
	}, plugin);
