### PR TITLE
Ensured plugin runners use caption as name if available

### DIFF
--- a/plugins/c9.ide.plugins/debug.js
+++ b/plugins/c9.ide.plugins/debug.js
@@ -365,7 +365,7 @@ define(function(require, exports, module) {
                     data = util.safeParseJson(data, function() {});
                     if (!data) return;
                     
-                    services.run.addRunner(filename, data, plugin);
+                    services.run.addRunner(data.caption || filename, data, plugin);
                     break;
                 case "snippets":
                     services["language.complete"].addSnippet(data, plugin);


### PR DESCRIPTION
Related to https://github.com/c9/c9.ide.run/issues/7, this patch ensures a packaged runner is loaded with the correct caption if one is set.