### PR TITLE
Allow folder hierarchy root name to be configurable

### DIFF
--- a/plugins/c9.fs/fs.cache.xml.js
+++ b/plugins/c9.fs/fs.cache.xml.js
@@ -633,7 +633,7 @@ define(function(require, exports, module) {
                     model.collapse(all[i]);
             }
             model.projectDir = {
-                label: c9.projectName, 
+                label: options.rootLabel || c9.projectName,
                 isFolder: true,
                 path: "/",
                 status: "pending",


### PR DESCRIPTION
Although we understand the rationale behind labeling the root of the file tree after the name of the project, we find it more consistent for our workspaces for that root icon to be named after the true name of the folder (in particular, "workspace" or maybe even "~/workspace"). This simple PR allows the default behavior without modification, but allows us to change the root title via workspace configuration, ala:
https://cloud9-sdk.readme.io/docs/custom-ide-configuration

Confirmed working by adding the following to the configuration above:
    else if (p.packagePath == "plugins/c9.fs/fs.cache.xml") {
        p.rootLabel = "workspace";
    }

This seems preferable to changing the c9.projectName in that same configuration file.