### PR TITLE
Adding a CSS class to identify core panel buttons

### DIFF
--- a/plugins/c9.ide.keys/panel.js
+++ b/plugins/c9.ide.keys/panel.js
@@ -26,6 +26,7 @@ define(function(require, exports, module) {
         var plugin = new Panel("Ajax.org", main.consumes, {
             index: options.index || 300,
             caption: "Commands",
+            buttonCSSClass: "commands",
             minWidth: 150,
             autohide: true,
             where: options.where || "left"

--- a/plugins/c9.ide.tree/tree.js
+++ b/plugins/c9.ide.tree/tree.js
@@ -46,6 +46,7 @@ define(function(require, exports, module) {
             index: options.index || 100,
             caption: "Workspace",
             panelCSSClass: "workspace_files",
+            buttonCSSClass: "workspace",
             minWidth: 130,
             where: options.where || "left"
         });


### PR DESCRIPTION
This will allow themes to identify core panel buttons and style them further.