### PR TITLE
unreadable color for the Gutter Tooltip in the flat dark theme

### DIFF
--- a/plugins/c9.ide.layout.classic/themes/default-flat-dark.less
+++ b/plugins/c9.ide.layout.classic/themes/default-flat-dark.less
@@ -798,7 +798,7 @@
 @gutter-tooltip-dark-shadow: 1px 1px 6px darken(rgba(0, 0, 0, 0.8), @darken-chrome);
 @gutter-tooltip-dark-background: darken(#FFF399, @darken-chrome);
 @gutter-tooltip-dark-border: black;
-@gutter-tooltip-dark-color: darken(#e0e3e8, @darken-chrome);
+@gutter-tooltip-dark-color: darken(#333, @darken-chrome);
 @gutter-tooltip-dark-font-smoothing: true;
 
 // Splitter


### PR DESCRIPTION
In the IDE, when using the experimental Dark Flat Theme, the gutter tooltip resulted in an unreadable color (see scr.), so I've changed it to the same color as the light theme (#333)

![untitled](https://cloud.githubusercontent.com/assets/1617990/12326241/dfe80dc2-bacf-11e5-88bc-6cf0cc0a24bd.jpg)
