### PR TITLE
Install script allow forked plugins

### DIFF
--- a/scripts/install-sdk.sh
+++ b/scripts/install-sdk.sh
@@ -94,7 +94,7 @@ updateAllPackages() {
 }
 
 updateAllDevPackages() {
-    c9packages=(`"$NODE" -e 'console.log(Object.keys(require("./package.json").devPlugins).join(" "))'`)
+    c9packages=(`"$NODE" -e 'console.log(Object.keys(require("./package.json").devPlugins || {}).join(" "))'`)
     githubUser=(`"$NODE" -e 'console.log(require("./package.json").devUser || "c9")'`)
     count=${#c9packages[@]}
     i=0
@@ -123,9 +123,10 @@ updateCore() {
     fi
     
     # without this git merge fails on windows
-    #mv ./scripts/install-sdk.sh  ./scripts/.install-sdk-tmp.sh 
-    #cp ./scripts/.install-sdk-tmp.sh ./scripts/install-sdk.sh
-    #git checkout -- ./scripts/install-sdk.sh
+    mv ./scripts/install-sdk.sh  './scripts/.#install-sdk-tmp.sh'
+    rm ./scripts/.install-sdk-tmp.sh 
+    cp './scripts/.#install-sdk-tmp.sh' ./scripts/install-sdk.sh
+    git checkout -- ./scripts/install-sdk.sh
 
     git remote add c9 https://github.com/c9/core 2> /dev/null || true
     git fetch c9

--- a/scripts/install-sdk.sh
+++ b/scripts/install-sdk.sh
@@ -50,17 +50,29 @@ FORCE=
 
 updatePackage() {
     name=$1
-    packageData=`"$NODE" -e 'console.log((require("../../package.json").c9plugins["'$name'"].substr(1) || "origin/master"))'`;
+    REPO=https://github.com
     GITHUBOWNER=c9
-    ID=(${packageData//@/ });
-    version=${ID[0]};
+    url=`"$NODE" -e 'console.log((require("./package.json").c9plugins["'$name'"].split("#")[0] || "c9"))'`
+    version=`"$NODE" -e 'console.log((require("./package.json").c9plugins["'$name'"].split("#")[1] || "origin/master"))'`
     
-    if [[ ${ID[1]} ]]; then
-        GITHUBOWNER=${ID[1]}
+    versionCheckAlt=(${version//@/ })
+    version=${versionCheckAlt[0]}
+    if [[ ${versionCheckAlt[1]} ]]; then
+        GITHUBOWNER=${versionCheckAlt[1]}
     fi
     
-    REPO=https://github.com/$GITHUBOWNER/$name
-    
+    urlCheckGit=(${url//it@/ })
+    if [[ ${urlCheckGit[1]} ]]; then
+        REPO=$url
+    else
+        urlCheckGit=(${url//:\/\// })
+        if [[ ${urlCheckGit[1]} ]]; then
+            REPO=$url
+        else
+            REPO=$REPO/$GITHUBOWNER/$name
+        fi
+    fi
+
     echo "${green}checking out ${resetColor}$REPO/tree/${red}$version${resetColor}"
     
     if ! [[ -d ./plugins/$name ]]; then

--- a/scripts/install-sdk.sh
+++ b/scripts/install-sdk.sh
@@ -61,7 +61,7 @@ updatePackage() {
     
     REPO=https://github.com/$GITHUBOWNER/$name
     
-    echo "${green}checking out ${resetColor}$REPO/tree/${red}#$version${resetColor}"
+    echo "${green}checking out ${resetColor}$REPO/tree/${red}$version${resetColor}"
     
     if ! [[ -d ./plugins/$name ]]; then
         mkdir -p ./plugins/$name

--- a/scripts/install-sdk.sh
+++ b/scripts/install-sdk.sh
@@ -50,7 +50,7 @@ FORCE=
 
 updatePackage() {
     name=$1
-    packageData=`"$NODE" -e 'var package = require("./package.json");console.log(package.c9plugins["'$name'"] ? package.c9plugins["'$name'"].substr(1) : package.devPlugins["'$name'"] ? package.devPlugins["'$name'"].substr(1) : "origin/master")'`;
+    packageData=`"$NODE" -e 'console.log((require("../../package.json").c9plugins["'$name'"].substr(1) || "origin/master"))'`;
     GITHUBOWNER=c9
     ID=(${packageData//@/ });
     version=${ID[0]};

--- a/scripts/install-sdk.sh
+++ b/scripts/install-sdk.sh
@@ -61,7 +61,7 @@ updatePackage() {
     
     REPO=https://github.com/$GITHUBOWNER/$name
     
-    echo "${green}checking out ${resetColor}$REPO${red}#$version${resetColor}"
+    echo "${green}checking out ${resetColor}$REPO/tree/${red}#$version${resetColor}"
     
     if ! [[ -d ./plugins/$name ]]; then
         mkdir -p ./plugins/$name


### PR DESCRIPTION
this makes it easy to create custom plugins in forks or testing core plugins in forks for testing before adding it to the core

```
{
    "c9plugins": {},

    "devUser": "bmatusiak-c9",
    "devPlugins": {
        "c9.ide.popup": "#f0f59b23cf"
    }
}
```

devUser Must be provided! <so it know where to get the forked plugins>
devPlugins matches c9plugins hierarchy

before submitting "pr"  revert package.json, then and add it to c9plugin object respectively
