### PR TITLE
#188 Adding crossorigin attribute to mocha and require scripts

### DIFF
--- a/plugins/c9.ide.plugins/test.html
+++ b/plugins/c9.ide.plugins/test.html
@@ -38,8 +38,8 @@
     <div id="mocha"></div>
     <div id='jserror' width='100%' height='20px' style='font: 10px \"courier new\"; color: red; display: none;'></div>
 
-    <script src="/static/require.js"></script>
-    <script src="/static/lib/mocha/mocha.js"></script>
+    <script src="/static/require.js" crossorigin="true"></script>
+    <script src="/static/lib/mocha/mocha.js" crossorigin="true"></script>
     <script>
         /*global mocha*/
         mocha.setup('bdd');


### PR DESCRIPTION
In relation to Issue #188: Running unit tests for C9 plugins leads to 404 errors when trying to fetch mocha