### PR TITLE
Mage update() functions generic for Forms and Dialigs

### DIFF
--- a/plugins/c9.ide.dialog/dialog.js
+++ b/plugins/c9.ide.dialog/dialog.js
@@ -245,14 +245,21 @@ define(function(require, module, exports) {
                                 dropdown.setAttribute("value", item.value);
                         break;
                         default:
-                            if ("value" in item)
-                                el.setAttribute('value', item.value);
                             if ("onclick" in item)
                                 el.onclick = item.onclick;
-                            if ("visible" in item)
-                                el.setAttribute("visible", item.visible);
-                            if ("zindex" in item)
-                                el.setAttribute("zindex", item.zindex);
+
+                            var ignoreList = ["onclick"];
+
+                            Object.keys(item).forEach(function(key) {
+                                if (ignoreList.indexOf(key) > -1) return;
+
+                                var attributeExists = el.attributes.some(function(attribute) {
+                                    return (attribute.name === key)
+                                });
+
+                                if (attributeExists)
+                                    el.setAttribute(key, item[key]);
+                            });
                         break;
                     }
                 });

--- a/plugins/c9.ide.dialog/dialog.js
+++ b/plugins/c9.ide.dialog/dialog.js
@@ -245,20 +245,38 @@ define(function(require, module, exports) {
                                 dropdown.setAttribute("value", item.value);
                         break;
                         default:
-                            if ("onclick" in item)
-                                el.onclick = item.onclick;
-
-                            var ignoreList = ["onclick"];
+                            // Attributes we are happy to set directly
+                            var validAttributes = [
+                                "value",
+                                "visible",
+                                "zindex",
+                                "disabled",
+                                "caption",
+                                "tooltip",
+                                "command",
+                                "class",
+                                "icon",
+                                "src",
+                                "submenu"
+                            ];
 
                             Object.keys(item).forEach(function(key) {
-                                if (ignoreList.indexOf(key) > -1) return;
+                                // Check for onclick explictly
+                                if (key === "onclick")
+                                    return el.onclick = item.onclick;
 
-                                var attributeExists = el.attributes.some(function(attribute) {
-                                    return (attribute.name === key)
-                                });
+                                // Check for attributes we know exist and will directly set
+                                if (validAttributes.indexOf(key) > -1)
+                                    return el.setAttribute(key, item[key]);
 
-                                if (attributeExists)
-                                    el.setAttribute(key, item[key]);
+                                // Otherwise, check if the object has the attribute to set
+                                if (el.attributes) {
+                                    var attributeExists = el.attributes.some(function(attribute) {
+                                        return (attribute.name === key);
+                                    });
+                                    if (attributeExists)
+                                        el.setAttribute(key, item[key]);
+                                }
                             });
                         break;
                     }

--- a/plugins/c9.ide.ui/forms.js
+++ b/plugins/c9.ide.ui/forms.js
@@ -481,20 +481,38 @@ define(function(require, exports, module) {
                             }
                         break;
                         default:
-                            if ("onclick" in item)
-                                el.lastChild.onclick = item.onclick;
-
-                            var ignoreList = ["onclick"];
+                            // Attributes we are happy to set directly
+                            var validAttributes = [
+                                "value",
+                                "visible",
+                                "zindex",
+                                "disabled",
+                                "caption",
+                                "tooltip",
+                                "command",
+                                "class",
+                                "icon",
+                                "src",
+                                "submenu"
+                            ];
 
                             Object.keys(item).forEach(function(key) {
-                                if (ignoreList.indexOf(key) > -1) return;
+                                // Check for onclick explictly
+                                if (key === "onclick")
+                                    return el.lastChild.onclick = item.onclick;
 
-                                var attributeExists = el.lastChild.attributes.some(function(attribute) {
-                                    return (attribute.name === key)
-                                });
+                                // Check for attributes we know exist and will directly set
+                                if (validAttributes.indexOf(key) > -1)
+                                    return el.lastChild.setAttribute(key, item[key]);
 
-                                if (attributeExists)
-                                    el.lastChild.setAttribute(key, item[key]);
+                                // Otherwise, check if the object has the attribute to set
+                                if (el.lastChild && el.lastChild.attributes) {
+                                    var attributeExists = el.lastChild.attributes.some(function(attribute) {
+                                        return (attribute.name === key);
+                                    });
+                                    if (attributeExists)
+                                        el.lastChild.setAttribute(key, item[key]);
+                                }
                             });
                         break;
                     }

--- a/plugins/c9.ide.ui/forms.js
+++ b/plugins/c9.ide.ui/forms.js
@@ -481,14 +481,21 @@ define(function(require, exports, module) {
                             }
                         break;
                         default:
-                            if ("value" in item)
-                                el.lastChild.setAttribute('value', item.value);
                             if ("onclick" in item)
                                 el.lastChild.onclick = item.onclick;
-                            if ("visible" in item)
-                                el.lastChild.setAttribute("visible", item.visible)
-                            if ("zindex" in item)
-                                el.lastChild.setAttribute("zindex", item.zindex)
+
+                            var ignoreList = ["onclick"];
+
+                            Object.keys(item).forEach(function(key) {
+                                if (ignoreList.indexOf(key) > -1) return;
+
+                                var attributeExists = el.lastChild.attributes.some(function(attribute) {
+                                    return (attribute.name === key)
+                                });
+
+                                if (attributeExists)
+                                    el.lastChild.setAttribute(key, item[key]);
+                            });
                         break;
                     }
                 })


### PR DESCRIPTION
The ```plugin.update()``` and ```form.update()``` functions outlined in the Dialog and Form SDK pages here:

https://cloud9-sdk.readme.io/docs/dialog
https://cloud9-sdk.readme.io/docs/form

Only supports a handful of attributes. This PR makes the ```update()``` functions generic by checking for the existence of an attribute and updating it if it exists.