### PR TITLE
Added fourth argument, `reset`, to `proposeLayoutChange` API

### DIFF
--- a/plugins/c9.ide.layout.classic/layout.js
+++ b/plugins/c9.ide.layout.classic/layout.js
@@ -214,7 +214,7 @@ define(function(require, exports, module) {
             }
         }
         
-        function proposeLayoutChange(kind, force, type) {
+        function proposeLayoutChange(kind, force, type, reset) {
             if (!force && settings.getBool("user/general/@propose"))
                 return;
             
@@ -225,7 +225,7 @@ define(function(require, exports, module) {
                     ignoreTheme = true;
                     var theme = {"dark": "flat-dark", "light": "flat-light"}[kind];
                     settings.set("user/general/@skin", theme);
-                    updateTheme(false, type);
+                    updateTheme(!!reset, type);
                     ignoreTheme = false;
                     settings.set("user/general/@propose", question.dontAsk);
                 },


### PR DESCRIPTION
We're currently trying to implement a button in Cloud9's menu bar that toggles the UI between light and dark skins, ideally without triggering a (recurring) dialog.

At the moment, there doesn't seem to be a way to force a change to `user/general/@skin`, as by calling `imports.layout.proposeLayoutChange`, without potentially triggering the dialog below in cases where a user has manually changed their syntax theme:

> **Would you like to reset colors to their default value?**
> Plugins like the terminal, the output window and others have default colors based on the main theme. Click Yes to reset the colors to the default colors for this theme.

Adding a `reset` parameter to `proposeLayoutChange` would seem to be the cleanest way to allow a caller to squelch that dialog without exposing `updateTheme` itself via the API. The result is that a user will still be prompted to approve the layout change (unless `user/general/@propose` has been set) but won't be further prompted to approve a reset of colors.

An alternative approach would be to add a `showDontAsk` to the **Would you like to reset colors to their default value?** dialog, but that felt like a more impactful change.

CC @danallan