### PR TITLE
Reverted proposeLayoutChange, added resetTheme to API

### DIFF
--- a/plugins/c9.ide.layout.classic/layout.js
+++ b/plugins/c9.ide.layout.classic/layout.js
@@ -214,7 +214,7 @@ define(function(require, exports, module) {
             }
         }
         
-        function proposeLayoutChange(kind, force, type, reset) {
+        function proposeLayoutChange(kind, force, type) {
             if (!force && settings.getBool("user/general/@propose"))
                 return;
             
@@ -225,7 +225,7 @@ define(function(require, exports, module) {
                     ignoreTheme = true;
                     var theme = {"dark": "flat-dark", "light": "flat-light"}[kind];
                     settings.set("user/general/@skin", theme);
-                    updateTheme(!!reset, type);
+                    updateTheme(false, type);
                     ignoreTheme = false;
                     settings.set("user/general/@propose", question.dontAsk);
                 },
@@ -355,6 +355,14 @@ define(function(require, exports, module) {
             menus.addItemByPath("Window/Presets/Sublime Mode", new ui.item({
                 onclick: function(){ setBaseLayout("sublime"); }
             }), 300, plugin);
+        }
+        
+        function resetTheme(theme, type) {
+            ignoreTheme = true;
+            settings.set("user/general/@skin", theme);
+            updateTheme(true);
+            emit("themeDefaults", {theme: theme, type: type});
+            ignoreTheme = false;
         }
         
         function resize(){
@@ -597,7 +605,7 @@ define(function(require, exports, module) {
             get theme(){
                 return theme;
             },
-            
+
             /**
              * Returns an AMLElement that can server as a parent.
              * @param {Plugin} plugin  The plugin for which to find the parent.
@@ -613,6 +621,13 @@ define(function(require, exports, module) {
              */
             initMenus: initMenus,
             
+            /**
+             * Resets theme (without questioning user).
+             * @param {String} theme  Theme to use.
+             * @param {String} type   Type of editor to use.
+             */
+            resetTheme: resetTheme,
+
             /**
              * Sets the layout in one of two default modes:
              * @param {"default"|"minimal"} type 


### PR DESCRIPTION
This commit reverts [yesterday's change](https://github.com/c9/core/pull/266) to `proposeLayoutChange`, which added a `reset` parameter to that function in order to provide the caller with the ability to squelch the **Would you like to reset colors to their default value?** dialog. Wasn't necessarily a bad addition, but we realized that calling `proposeLayoutChange` with a value of `true` for `force` doesn't yield the best UX anyway, since it overrides that dialog's `showDontAsk` checkbox, even if the user has checked it previously (which a user would likely feel is a bug).

This PR instead proposes the addition of a `resetTheme` API method that would allow a caller to induce a theme change without prompting the user. (The intended use case is implementation of a button that toggles between day and night themes.)

Originally, we implemented `resetTheme` as a setter for `theme` (complementing the existing getter for `theme`), but doing so revealed a potential race condition:

1. A caller calls `settings.on("user/general/@skin", f);`.
1. A caller sets theme with `imports.layout.theme = theme;`.
1. Our setter calls `settings.set("user/general/@skin", theme);`.
1. `f` gets invoked and tries to access the new theme via `imports.layout.theme`, the getter, but `theme` is only set once `updateTheme` is called.
1. Our setter calls `updateTheme` (too late).

To avoid that scenario altogether, it seemed safest not to implement the setter. 

Though this potential for race conditions does seem to be an inherent side effect of using `settings.set` (a la an API call) to set keys like `user/general/@skin`, which are allowed to have onchange listeners, even though those keys are thus set *before* the underlying state (`imports.layout.theme` in this case) is updated? Seemed best not to stray from that design pattern with this particular commit, though!

CC @danallan 