### PR TITLE
Added CLI exec command

### DIFF
--- a/configs/cli.js
+++ b/configs/cli.js
@@ -81,6 +81,10 @@ return [
         platform: process.platform
     },
     {
+        packagePath: "./c9.cli.exec/exec",
+        platform: process.platform
+    },
+    {
         packagePath: "./c9.cli.open/restart",
         platform: process.platform
     },

--- a/plugins/c9.cli.bridge/bridge_commands.js
+++ b/plugins/c9.cli.bridge/bridge_commands.js
@@ -2,7 +2,7 @@
 define(function(require, exports, module) {
     main.consumes = [
         "Plugin", "bridge", "tabManager", "panels", "tree.favorites", "tree", 
-        "fs", "preferences", "settings", "c9"
+        "fs", "preferences", "settings", "c9", "commands"
     ];
     main.provides = ["bridge.commands"];
     return main;
@@ -18,6 +18,7 @@ define(function(require, exports, module) {
         var fs = imports.fs;
         var c9 = imports.c9;
         var prefs = imports.preferences;
+        var commands = imports.commands;
         
         var async = require("async");
         
@@ -35,6 +36,9 @@ define(function(require, exports, module) {
                 switch (message.type) {
                     case "open":
                         open(message, e.respond);
+                        break;
+                    case "exec":
+                        exec(message, e.respond);
                         break;
                     case "pipe":
                         createPipe(message, e.respond);
@@ -172,6 +176,12 @@ define(function(require, exports, module) {
                 if (!message.wait || !tabs.length)
                     callback(null, true);
             });
+        }
+
+        function exec(message, callback) {
+            var result = commands.exec(message.command, message.args);
+            var err = result ? null : "command failed";
+            callback(err, result);
         }
         
         /***** Lifecycle *****/

--- a/plugins/c9.cli.exec/exec.js
+++ b/plugins/c9.cli.exec/exec.js
@@ -1,0 +1,92 @@
+define(function(require, exports, module) {
+    main.consumes = ["Plugin", "cli_commands", "bridge.client"];
+    main.provides = ["exec"];
+    return main;
+
+    function main(options, imports, register) {
+        var Plugin = imports.Plugin;
+        var cmd = imports.cli_commands;
+        var bridge = imports["bridge.client"];
+
+        /***** Initialization *****/
+        
+        var plugin = new Plugin("Ajax.org", main.consumes);
+        // var emit = plugin.getEmitter();
+
+        var loaded;
+        function load(){
+            if (loaded) return;
+            loaded = true;
+            
+            cmd.addCommand({
+                name: "exec", 
+                info: "     Executes remote c9 commands.",
+                usage: "<command> [argument 1] [argument 2] ... [argument n]",
+                check: function(argv) {
+                    if (argv._.length < 2)
+                        throw new Error("Missing command");
+                },
+                options: {},
+                exec: function(argv) {
+                    exec(
+                        argv._[1],
+                        argv._.slice(2),
+                        function(){});
+                }
+            });
+        }
+
+        /***** Methods *****/
+
+        function exec(command, args, callback) {
+            args.unshift(process.cwd());
+            var message = {
+                type: "exec",
+                command: command,
+                args: args
+            };
+            
+            bridge.send(message, function cb(err, response) {
+                if (err) {
+                    console.log(err.message);
+                }
+                
+                if (response !== true)
+                    console.log("Could not execute", command);
+                
+                process.exit(); // I don't get why this is needed
+            });
+        }
+
+        /***** Lifecycle *****/
+        
+        plugin.on("load", function(){
+            load();
+        });
+        plugin.on("enable", function(){
+            
+        });
+        plugin.on("disable", function(){
+            
+        });
+        plugin.on("unload", function(){
+            loaded = false;
+        });
+        
+        /***** Register and define API *****/
+
+        /**
+         * Finds or lists files and/or lines based on their filename or contents
+         **/
+        plugin.freezePublicAPI({
+            /**
+             *
+             */
+            exec: exec
+        });
+        
+        register(null, {
+            exec: plugin
+        });
+    }
+});


### PR DESCRIPTION
@nightwing 
This PR adds the ability to execute registered c9 UI commands (using ```commands.add```) from the command-line.

I've suggested this due to our need to run build commands from the command-line.
I was unable to find an extension point for the CLI and felt this solution was more generic and offers extra functionality to all.