### PR TITLE
Fixes left-padding in flat themes for a button whose caption is ""

### DIFF
--- a/plugins/c9.ide.layout.classic/themes/flat-light.less
+++ b/plugins/c9.ide.layout.classic/themes/flat-light.less
@@ -33,6 +33,10 @@
     padding-left: 33px !important;
 }
 
+.c9-menu-btnEmpty {
+    padding-left: 9px;
+}
+
 .c9-menu-btnDown:not(.c9-menu-btnmenuDown){
     box-shadow: none;
     border: 0;


### PR DESCRIPTION
When using a flat theme, buttons with empty captions have a default `padding-left` of `7px`, per https://github.com/c9/core/blob/master/plugins/c9.ide.layout.classic/less/c9-menu-btn.less#L96. However, when clicked, `left-padding` becomes `9px`, per https://github.com/c9/core/blob/master/plugins/c9.ide.layout.classic/themes/flat-light.less#L36, the result of which is a (presumably unintended) left-shift of the button while clicked. This PR changes empty captions' default `padding-left` to be `9px` as well.

CC @danallan 