### PR TITLE
Update makelocal.sh invocation in setup-local-dev.sh

### DIFF
--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -160,7 +160,8 @@ if [ "$os" == "windows" ]; then
     cscript //NoLogo //B //E:jscript ./shortcut.wscript.js
     rm -f ./shortcut.wscript.js
     
-    bash ./makelocal.sh
+    current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    bash "$current_dir/makelocal.sh"
 fi
 
 


### PR DESCRIPTION
Currently, if we invoke `setup-local-dev.sh` from the root directly of the repository like this

    ./scripts/setup-local-dev.sh

We get the error that `makelocal.sh` is not found, since the command to invoke it is:

    bash ./makelocal.sh

This fix works on Windows (MinGW) and Ubuntu, so I guess it be on pretty much any UNIX platform.

