### PR TITLE
Issue with packed mode on Windows

### DIFF
--- a/node_modules/architect-build/module-deps.js
+++ b/node_modules/architect-build/module-deps.js
@@ -113,6 +113,7 @@ module.exports = function(mains, opts) {
     }
     
     function setModuleSource(mod, src, cb) {
+        src = src && src.replace(/\r\n/g, '\n');
         if (cache)
             cache.files[mod.file] = src;
         mod.source = src;


### PR DESCRIPTION
I ran into an issue in packed mode on Windows. There is some code to embed `text!` imports into the packed config file, which escapes newlines to avoid generating illegal JavaScript string constants that wrap onto multiple lines (this is in `architect-build/build.js`):

    var source = pkg.source.replace(/\\/g, '\\\\').replace(/\n/g, "\\n").replace(/"/g, '\\"');

On Windows, Git checks out the source files using Windows line endings, so although the `\n` characters get removed, the `\r` characters are left behind, which still results in illegal JavaScript, so the browser fails to parse the packed config file.

I have fixed it locally by converting `\r\n` into `\n` when reading the source files, as recommended by @nightwing in https://groups.google.com/forum/#!topic/cloud9-sdk/1B2i6Y88Ckw.