### PR TITLE
Fixed error in Windows when clicking run button

### DIFF
--- a/node_modules/vfs-local/localfs.js
+++ b/node_modules/vfs-local/localfs.js
@@ -2094,7 +2094,7 @@ module.exports = function setup(fsOptions) {
         // Kill the session with the same name before starting a new one
         if (options.kill) {
             session = sessions[options.session];
-            if (session)
+            if (session && session.pty)
                 session.pty.kill();
             
             if (!options.command)


### PR DESCRIPTION
Fixes the following bug:

- Run something in the IDE (keep the output pane open)
- Restart server.js
- Reload the IDE in your browser (the output pane should still be there)
- Click the run button in the output pane

**Expected:** The process gets run again.
**Actual:** An error occurs.
