### PR TITLE
Support for downloading workspace files as a zip archive

### DIFF
--- a/plugins/c9.vfs.server/download_test.js
+++ b/plugins/c9.vfs.server/download_test.js
@@ -53,8 +53,9 @@ describe(__filename, function(){
 
     describe("download", function() {
     
-        it("should download", function(next) {
+        it("should download as tar", function(next) {
             tmp.dir({unsafeCleanup: true}, function(err, path) {
+                path = path.replace(/\w:/, '');
                 var filename = path + "/download.tar.gz";
                 var file = fs.createWriteStream(filename);
                 http.get("http://localhost:8787/?download=download.tar.gz", function(res) {
@@ -77,21 +78,22 @@ describe(__filename, function(){
             });
         });
     
-        it("should download sub directory", function(next) {
+        it("should download sub directory as tar", function(next) {
             tmp.dir({unsafeCleanup: true}, function(err, path) {
+                path = path.replace(/\w:/, '');
                 assert.equal(err, null);
                 
                 var filename = path + "/download.tar.gz";
                 var file = fs.createWriteStream(filename);
-                http.get("http://localhost:8787/views?download=download.tar.gz", function(res) {
+                http.get("http://localhost:8787/test?download=download.tar.gz", function(res) {
                     res.pipe(file);
                     
                     res.on("end", function() {
-                        execFile("tar", ["-zxvf", filename, "views/status.html.ejs"], {cwd: path}, function(err) {
+                        execFile("tar", ["-zxvf", filename, "test/dir1/testdata1.txt"], {cwd: path}, function(err) {
                             assert.equal(err, null);
                             assert.equal(
-                                fs.readFileSync(__dirname + "/views/status.html.ejs", "utf8"),
-                                fs.readFileSync(path + "/views/status.html.ejs", "utf8")
+                                fs.readFileSync(__dirname + "/test/dir1/testdata1.txt", "utf8"),
+                                fs.readFileSync(path + "/test/dir1/testdata1.txt", "utf8")
                             );
                             next();
                         });
@@ -102,22 +104,180 @@ describe(__filename, function(){
     
         it("should download without specifying a name", function(next) {
             tmp.dir({unsafeCleanup: true}, function(err, path) {
+                path = path.replace(/\w:/, '');
                 assert.equal(err, null);
                 
                 var filename = path + "/download.tar.gz";
                 var file = fs.createWriteStream(filename);
-                http.get("http://localhost:8787/views?download", function(res) {
+                http.get("http://localhost:8787/test?download", function(res) {
                     assert.equal(res.headers["content-type"], "application/x-gzip");
-                    assert.equal(res.headers["content-disposition"], "attachment; filename*=utf-8''views.tar.gz");
+                    assert.equal(res.headers["content-disposition"], "attachment; filename*=utf-8''test.tar.gz");
                     
                     res.pipe(file);
                     
                     res.on("end", function() {
-                        execFile("tar", ["-zxvf", filename, "views/status.html.ejs"], {cwd: path}, function(err) {
+                        execFile("tar", ["-zxvf", filename, "test/dir1/testdata1.txt"], {cwd: path}, function(err) {
                             assert.equal(err, null);
                             assert.equal(
-                                fs.readFileSync(__dirname + "/views/status.html.ejs", "utf8"),
-                                fs.readFileSync(path + "/views/status.html.ejs", "utf8")
+                                fs.readFileSync(__dirname + "/test/dir1/testdata1.txt", "utf8"),
+                                fs.readFileSync(path + "/test/dir1/testdata1.txt", "utf8")
+                            );
+                            next();
+                        });
+                    });
+                });
+            });
+        });
+
+        it("should download several files in same directory as tar", function(next) {
+            tmp.dir({unsafeCleanup: true}, function(err, path) {
+                path = path.replace(/\w:/, '');
+                assert.equal(err, null);
+
+                var filename = path + "/download.tar.gz";
+                var file = fs.createWriteStream(filename);
+                http.get("http://localhost:8787/test/dir2/testdata2a.txt,/test/dir2/testdata2b.txt?download=download.tar.gz", function(res) {
+                    res.pipe(file);
+                    res.on("end", function() {
+                        execFile("tar", ["-zxvf", filename], {cwd: path}, function(err) {
+                            assert.equal(err, null);
+                            assert.equal(
+                                fs.readFileSync(__dirname + "/test/dir2/testdata2a.txt", "utf8"),
+                                fs.readFileSync(path + "/testdata2a.txt", "utf8")
+                            );
+                            assert.equal(
+                                fs.readFileSync(__dirname + "/test/dir2/testdata2b.txt", "utf8"),
+                                fs.readFileSync(path + "/testdata2b.txt", "utf8")
+                            );
+                            next();
+                        });
+                    });
+                });
+            });
+        });
+
+        it("should download several files in different directories as tar", function(next) {
+            tmp.dir({unsafeCleanup: true}, function(err, path) {
+                path = path.replace(/\w:/, '');
+                assert.equal(err, null);
+
+                var filename = path + "/download.tar.gz";
+                var file = fs.createWriteStream(filename);
+                http.get("http://localhost:8787/test/dir1/testdata1.txt,/test/dir2/testdata2a.txt?download=download.tar.gz", function(res) {
+                    res.pipe(file);
+                    res.on("end", function() {
+                        execFile("tar", ["-zxvf", filename], {cwd: path}, function(err) {
+                            assert.equal(err, null);
+                            assert.equal(
+                                fs.readFileSync(__dirname + "/test/dir1/testdata1.txt", "utf8"),
+                                fs.readFileSync(path + "/dir1/testdata1.txt", "utf8")
+                            );
+                            assert.equal(
+                                fs.readFileSync(__dirname + "/test/dir2/testdata2a.txt", "utf8"),
+                                fs.readFileSync(path + "/dir2/testdata2a.txt", "utf8")
+                            );
+                            next();
+                        });
+                    });
+                });
+            });
+        });
+
+        it("should download as zip", function(next) {
+            tmp.dir({unsafeCleanup: true}, function(err, path) {
+                path = path.replace(/\w:/, '');
+                var filename = path + "/download.zip";
+                var file = fs.createWriteStream(filename);
+                http.get("http://localhost:8787/?download=download.zip", function(res) {
+                    assert.equal(res.headers["content-type"], "application/zip");
+                    assert.equal(res.headers["content-disposition"], "attachment; filename*=utf-8''download.zip");
+
+                    res.pipe(file);
+
+                    res.on("end", function() {
+                        execFile("unzip", [filename, "c9.vfs.server/download.js"], {cwd: path}, function(err, stdout, stderr) {
+                            assert.equal(err, null);
+                            assert.equal(
+                                fs.readFileSync(__dirname + "/download.js", "utf8"),
+                                fs.readFileSync(path + "/c9.vfs.server/download.js", "utf8")
+                            );
+                            next();
+                        });
+                    });
+                });
+            });
+        });
+
+        it("should download sub directory as zip", function(next) {
+            tmp.dir({unsafeCleanup: true}, function(err, path) {
+                path = path.replace(/\w:/, '');
+                assert.equal(err, null);
+
+                var filename = path + "/download.zip";
+                var file = fs.createWriteStream(filename);
+                http.get("http://localhost:8787/test?download=download.zip", function(res) {
+                    res.pipe(file);
+
+                    res.on("end", function() {
+                        execFile("unzip", [filename, "test/dir1/testdata1.txt"], {cwd: path}, function(err) {
+                            assert.equal(err, null);
+                            assert.equal(
+                                fs.readFileSync(__dirname + "/test/dir1/testdata1.txt", "utf8"),
+                                fs.readFileSync(path + "/test/dir1/testdata1.txt", "utf8")
+                            );
+                            next();
+                        });
+                    });
+                });
+            });
+        });
+
+        it("should download several files in same directory as zip", function(next) {
+            tmp.dir({unsafeCleanup: true}, function(err, path) {
+                path = path.replace(/\w:/, '');
+                assert.equal(err, null);
+
+                var filename = path + "/download.zip";
+                var file = fs.createWriteStream(filename);
+                http.get("http://localhost:8787/test/dir2/testdata2a.txt,/test/dir2/testdata2b.txt?download=download.zip", function(res) {
+                    res.pipe(file);
+                    res.on("end", function() {
+                        execFile("unzip", [filename], {cwd: path}, function(err) {
+                            assert.equal(err, null);
+                            assert.equal(
+                                fs.readFileSync(__dirname + "/test/dir2/testdata2a.txt", "utf8"),
+                                fs.readFileSync(path + "/testdata2a.txt", "utf8")
+                            );
+                            assert.equal(
+                                fs.readFileSync(__dirname + "/test/dir2/testdata2b.txt", "utf8"),
+                                fs.readFileSync(path + "/testdata2b.txt", "utf8")
+                            );
+                            next();
+                        });
+                    });
+                });
+            });
+        });
+
+        it("should download several files in different directories as zip", function(next) {
+            tmp.dir({unsafeCleanup: true}, function(err, path) {
+                path = path.replace(/\w:/, '');
+                assert.equal(err, null);
+
+                var filename = path + "/download.zip";
+                var file = fs.createWriteStream(filename);
+                http.get("http://localhost:8787/test/dir1/testdata1.txt,/test/dir2/testdata2a.txt?download=download.zip", function(res) {
+                    res.pipe(file);
+                    res.on("end", function() {
+                        execFile("unzip", [filename], {cwd: path}, function(err) {
+                            assert.equal(err, null);
+                            assert.equal(
+                                fs.readFileSync(__dirname + "/test/dir1/testdata1.txt", "utf8"),
+                                fs.readFileSync(path + "/dir1/testdata1.txt", "utf8")
+                            );
+                            assert.equal(
+                                fs.readFileSync(__dirname + "/test/dir2/testdata2a.txt", "utf8"),
+                                fs.readFileSync(path + "/dir2/testdata2a.txt", "utf8")
                             );
                             next();
                         });

--- a/plugins/c9.vfs.server/test/dir1/testdata1.txt
+++ b/plugins/c9.vfs.server/test/dir1/testdata1.txt
@@ -1,0 +1,1 @@
+test data 1

--- a/plugins/c9.vfs.server/test/dir2/testdata2a.txt
+++ b/plugins/c9.vfs.server/test/dir2/testdata2a.txt
@@ -1,0 +1,1 @@
+test data 2a

--- a/plugins/c9.vfs.server/test/dir2/testdata2b.txt
+++ b/plugins/c9.vfs.server/test/dir2/testdata2b.txt
@@ -1,0 +1,1 @@
+test data 2b


### PR DESCRIPTION
As discussed at https://groups.google.com/forum/#!topic/cloud9-sdk/OimcqUjSun0.

- A new user preference is added, `Download Files As: auto/zip/tar.gz`. The default is `auto`, which uses `zip` on Windows and `tar.gz` on Linux/OS X.
- As previously, the file or folder selected for download appears at the root of the zip or tar archive.
- When downloading several files/folders, the zip or tar archive now stores the files relative to their common parent directory. (E.g., if `/a/b/c` and `/a/b/d` are selected, the archive contains `c` and `d`, whereas if `/a/b/c` and `/a/e/f` are selected, the archive contains `b/c` and `e/f`.)
- Files starting with `-` are handled using the `--` option to `tar` and `zip`.
- Unit tests are included for the new behaviour, plus a `test` directory containing some source files used in the tests. They are passing on Windows and Linux.

See also https://github.com/cloud9ide/sdk-deps-win32/pull/1, to add the msys zip utility to the Windows SDK dependencies.