### PR TITLE
Improvements to download as zip

### DIFF
--- a/plugins/c9.ide.download/download.js
+++ b/plugins/c9.ide.download/download.js
@@ -91,22 +91,28 @@ define(function(require, exports, module) {
         }
 
         function downloadProject() {
-            vfs.download("/", info.getWorkspace().name + getArchiveFileExtension());
+            vfs.download("/", makeArchiveFilename(info.getWorkspace().name));
         }
 
         function downloadPaths(paths) {
-            vfs.download(paths, info.getWorkspace().name + getArchiveFileExtension());
+            var lastPart = paths[0].match(/([^\/]*)\/?$/)[1];
+            var filename = lastPart ? (lastPart + "[+" + (paths.length - 1) + "]") : info.getWorkspace().name;
+            vfs.download(paths, makeArchiveFilename(filename));
         }
 
         function downloadFolder(path) {
             var withTrailingSlash = path.replace(/\/*$/, "/");
             var parts = withTrailingSlash.split("/");
-            var lastPart = parts[parts.length - 2];
-            vfs.download(withTrailingSlash, lastPart + getArchiveFileExtension());
+            var folderName = parts[parts.length - 2];
+            vfs.download(withTrailingSlash, makeArchiveFilename(folderName));
         }
 
         function downloadFile(path) {
             vfs.download(path.replace(/\/*$/, ""), null, true);
+        }
+
+        function makeArchiveFilename(filename) {
+            return filename + getArchiveFileExtension();
         }
 
         function getArchiveFileExtension() {

--- a/plugins/c9.vfs.client/vfs_client.js
+++ b/plugins/c9.vfs.client/vfs_client.js
@@ -193,12 +193,13 @@ define(function(require, exports, module) {
                 extraPaths = path;
                 path = path[0];
                 extraPaths = "," + extraPaths.map(function(p) {
-                    return p[0] == path[0] && p != path ? encodeURI(p).replace(/,/g, "%2C") : "";
+                    return p[0] == path[0] && p != path ? escape(p) : "";
                 }).filter(Boolean).join(",");
             }
             window.open(vfsUrl(path) + extraPaths
                 + "?download" 
-                + (filename ? "=" + encodeURIComponent(filename) : "")
+                // Escape '+', otherwise it gets interpreted as a space.
+                + (filename ? "=" + escape(filename) : "").replace(/\+/g, "%2B")
                 + (isfile ? "&isfile=1" : ""));
         }
 

--- a/plugins/c9.vfs.client/vfs_client.js
+++ b/plugins/c9.vfs.client/vfs_client.js
@@ -193,7 +193,7 @@ define(function(require, exports, module) {
                 extraPaths = path;
                 path = path[0];
                 extraPaths = "," + extraPaths.map(function(p) {
-                    return p[0] == path[0] && p != path ? encodeURI(p) : "";
+                    return p[0] == path[0] && p != path ? encodeURI(p).replace(/,/g, "%2C") : "";
                 }).filter(Boolean).join(",");
             }
             window.open(vfsUrl(path) + extraPaths

--- a/plugins/c9.vfs.client/vfs_client.js
+++ b/plugins/c9.vfs.client/vfs_client.js
@@ -193,12 +193,12 @@ define(function(require, exports, module) {
                 extraPaths = path;
                 path = path[0];
                 extraPaths = "," + extraPaths.map(function(p) {
-                    return p[0] == path[0] && p != path ? escape(p) : "";
+                    return p[0] == path[0] && p != path ? encodeURI(p) : "";
                 }).filter(Boolean).join(",");
             }
             window.open(vfsUrl(path) + extraPaths
                 + "?download" 
-                + (filename ? "=" + escape(filename) : "")
+                + (filename ? "=" + encodeURIComponent(filename) : "")
                 + (isfile ? "&isfile=1" : ""));
         }
 

--- a/plugins/c9.vfs.server/download.js
+++ b/plugins/c9.vfs.server/download.js
@@ -113,10 +113,8 @@ define(function(require, exports, module) {
                 paths.forEach(function(path) {
                     if (!path) return;
                     path = Path.relative(cwd, path);
-                    // tar misinterprets the Windows path separator as an escape sequence, so use forward slash.
-                    if (Path.sep === '\\') {
-                        path = path.replace(/\\/g, '/');
-                    }
+                    // Single quote the path to escape unusual characters, and manually escape single quotes.
+                    path = "'" + path.replace(/'/, "'\\''") + "'";
                     args.push(path);
                 });
 

--- a/plugins/c9.vfs.server/download.js
+++ b/plugins/c9.vfs.server/download.js
@@ -44,7 +44,7 @@ define(function(require, exports, module) {
                     filename += (paths.length > 1 ? "[+" + (paths.length - 1) + "]"  : "") + ".tar.gz";
                 }
             }
-            var filenameHeader = "attachment; filename*=utf-8''" + encodeURIComponent(filename);
+            var filenameHeader = "attachment; filename*=utf-8''" + escape(filename);
 
             var process;
             req.on("close", function() {


### PR DESCRIPTION
@nightwing As discussed, selecting several files/folders and downloading them results in a file named `file1[+n].zip` where `n` is the total number of files/folders selected.

Using a filename containing `[` and `]` revealed some problems with URI encoding, so I fixed those too. I'm using `encodeURI` to encode the path component of the download URL, and `encodeURIComponent` for the `download` parameter. This seems to give the correct behaviour across a variety of unusual filename characters, including `!$%^&()-_=+[]{};@#~,`.
