### PR TITLE
changes on-hover bg color for Run and Preview

### DIFF
--- a/plugins/c9.ide.layout.classic/themes/flat-dark.less
+++ b/plugins/c9.ide.layout.classic/themes/flat-dark.less
@@ -1,7 +1,7 @@
 @import "plugins/c9.ide.layout.classic/themes/flat-light.less";
 
 .bartools .c9-toolbarbutton-glossyOver{
-    background: #E6E6E6;
+    background: #303130;
 }
 
 .bartools .c9-toolbarbutton-glossymenuDown{


### PR DESCRIPTION
the on-hover background color for Run/Debug and Preview buttons is
brighter than it should (`#E6E6E6`) in Cloud9 Night theme. it doesn't
match that of the menus.

![before-](https://cloud.githubusercontent.com/assets/7230211/15503339/b6ef1e3c-21b9-11e6-86b2-1667e0fba421.png)

this changes the value of the `background` CSS property, of the relevant
classes, to the matching color (`#303130`).

![after-](https://cloud.githubusercontent.com/assets/7230211/15503353/c514bd1e-21b9-11e6-9536-57590196c8b3.png)
