### PR TITLE
Server script added

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Default settings
+BASEPATH=$(dirname $0)
+CONFPATH="$HOME/.c9/user.service"
+NODEPATH="node"
+CLOUDAPP=$(realpath "$BASEPATH/../server.js")
+BINDADDR="127.0.0.1"
+BINDPORT="8181"
+USERNAME="$USER"
+PASSWORD="$USER"
+WORKPATH="$HOME/workspace"
+SETTINGS="standard"
+
+# Load user settings if it exists
+if [ -f $CONFPATH ]; then
+	source $CONFPATH
+fi
+
+# Start service
+$NODEPATH $CLOUDAPP -l $BINDADDR -p $BINDPORT \
+    -a $USERNAME:$PASSWORD -w $WORKPATH -s $SETTINGS

--- a/bin/server
+++ b/bin/server
@@ -10,7 +10,7 @@ BINDPORT="8181"
 USERNAME="$USER"
 PASSWORD="$USER"
 WORKPATH="$HOME/workspace"
-SETTINGS="standard"
+SETTINGS="standalone"
 
 # Load user settings if it exists
 if [ -f $CONFPATH ]; then

--- a/etc/systemd/system/cloud9@.service
+++ b/etc/systemd/system/cloud9@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cloud9 online IDE
+After=syslog.target network.target
+
+[Service]
+User=%i
+ExecStart=/opt/cloud9/bin/server
+Restart=on-failure
+StandardOutput=syslog
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Helper script to start server without long command lines. Settings can be
defined on ~/.c9/user.service and server started with "bin/server".

This script can be also called from systemd unit. You can have 
/etc/systemd/system/cloud9@.service with this contents:

```ini
[Unit]
Description=Cloud9 online IDE
After=syslog.target network.target

[Service]
User=%i
ExecStart=/opt/cloud9/bin/server

Restart=on-failure
StandardOutput=syslog

[Install]
WantedBy=multi-user.target
```

This can be installed with:

```bash
install -Dm644 cloud9@.service /etc/systemd/system/cloud9@.service
systemctl daemon-reload
```

Also, you can start it using:

```bash
systemctl start cloud9@user.service
```

Or make it started by default on your system:

```bash
systemctl enable cloud9@user.service
```
