### PR TITLE
Exclude file formats from opening

### DIFF
--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -1077,25 +1077,25 @@ define(function(require, module, exports) {
             //     options.document.filter = true;
             options.editorType = type;
             
-            //Obtain lst of excluded file formats
+            // Obtain lst of excluded file formats
             var lst = settings.get("user/tabs/@excludeFormats");
             lst = lst.replace(new RegExp(" ", "g"), "");
-            lst = (lst.split(",")).filter(function(n) {
+            lst = lst.split(",").filter(function(n) {
                 return (n !== "");
             });
             
-            //Extension of file being opened
+            // Extension of file being opened
             var ext = path.substr(path.lastIndexOf(".") + 1);
             
-            //Create the tab, if not forbiden format
-            if (lst.indexOf(ext)!=-1) {
+            // Create the tab, if not forbiden format
+            if (lst.indexOf(ext) != -1) {
                 alert("Can't open " + path.substr(path.lastIndexOf('/') + 1) 
                     + ": file format unsupported");
                 return;
             } 
-            else { 
-                 tab = createTab(options);
-            }
+            
+            // Create the tab
+            tab = createTab(options);
             
             // Focus
             if (options.focus)

--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -1077,8 +1077,25 @@ define(function(require, module, exports) {
             //     options.document.filter = true;
             options.editorType = type;
             
-            // Create the tab
-            tab = createTab(options);
+            //Obtain lst of forbidden file formats
+            var lst = settings.get("user/forbidden/@formats");
+            lst = lst.replace(new RegExp(" ", "g"), "");
+            lst = (lst.split(",")).filter(function(n){
+                return (n !== "");
+            });
+            
+            //Extension of file being opened
+            var ext = path.substr(path.lastIndexOf(".") + 1);
+            
+            //Create the tab, if not forbiden format
+            if (lst.indexOf(ext)!=-1){
+                alert("Can't open " + path.substr(path.lastIndexOf('/') + 1) 
+                    + ": file format unsupported");
+                return;
+            } 
+            else{ 
+                 tab = createTab(options);
+            }
             
             // Focus
             if (options.focus)

--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -1081,13 +1081,14 @@ define(function(require, module, exports) {
             // Obtain lst of excluded file formats
             var lst = settings.get("user/tabs/@excludeFormats")
                 .replace(new RegExp(" ", "g"), "")
+                .toLowerCase()
                 .split(",")
                 .filter(function(n) {
                     return (n !== "");
                 });
             
             // Extension of file being opened
-            var ext = extname(path).substr(1);
+            var ext = extname(path).substr(1).toLowerCase();
             
             // Create the tab, if not forbiden format
             if (lst.indexOf(ext) != -1) {

--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -1078,11 +1078,12 @@ define(function(require, module, exports) {
             options.editorType = type;
             
             // Obtain lst of excluded file formats
-            var lst = settings.get("user/tabs/@excludeFormats");
-            lst = lst.replace(new RegExp(" ", "g"), "");
-            lst = lst.split(",").filter(function(n) {
-                return (n !== "");
-            });
+            var lst = settings.get("user/tabs/@excludeFormats")
+                .replace(new RegExp(" ", "g"), "")
+                .split(",")
+                .filter(function(n) {
+                    return (n !== "");
+                });
             
             // Extension of file being opened
             var ext = path.substr(path.lastIndexOf(".") + 1);

--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -1077,10 +1077,10 @@ define(function(require, module, exports) {
             //     options.document.filter = true;
             options.editorType = type;
             
-            //Obtain lst of forbidden file formats
-            var lst = settings.get("user/forbidden/@formats");
+            //Obtain lst of excluded file formats
+            var lst = settings.get("user/tabs/@excludeformats");
             lst = lst.replace(new RegExp(" ", "g"), "");
-            lst = (lst.split(",")).filter(function(n){
+            lst = (lst.split(",")).filter(function(n) {
                 return (n !== "");
             });
             
@@ -1088,12 +1088,12 @@ define(function(require, module, exports) {
             var ext = path.substr(path.lastIndexOf(".") + 1);
             
             //Create the tab, if not forbiden format
-            if (lst.indexOf(ext)!=-1){
+            if (lst.indexOf(ext)!=-1) {
                 alert("Can't open " + path.substr(path.lastIndexOf('/') + 1) 
                     + ": file format unsupported");
                 return;
             } 
-            else{ 
+            else { 
                  tab = createTab(options);
             }
             

--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -25,6 +25,7 @@ define(function(require, module, exports) {
         var alert = imports["dialog.alert"].show;
         
         var basename = require("path").basename;
+        var extname = require("path").extname;
         
         /***** Initialization *****/
         
@@ -1086,11 +1087,11 @@ define(function(require, module, exports) {
                 });
             
             // Extension of file being opened
-            var ext = path.substr(path.lastIndexOf(".") + 1);
+            var ext = extname(path).substr(1);
             
             // Create the tab, if not forbiden format
             if (lst.indexOf(ext) != -1) {
-                alert("Can't open " + path.substr(path.lastIndexOf('/') + 1) 
+                alert("Can't open " + basename(path) 
                     + ": file format unsupported");
                 return;
             } 

--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -1078,7 +1078,7 @@ define(function(require, module, exports) {
             options.editorType = type;
             
             //Obtain lst of excluded file formats
-            var lst = settings.get("user/tabs/@excludeformats");
+            var lst = settings.get("user/tabs/@excludeFormats");
             lst = lst.replace(new RegExp(" ", "g"), "");
             lst = (lst.split(",")).filter(function(n) {
                 return (n !== "");


### PR DESCRIPTION
Additional code whereby the user can specify a list of comma-separated file extensions via the user settings file, to prevent all files with those extensions from being opened.

I am working with CS50 and want the ability to prevent people from opening certain specified file types, such as binary files. We would use this for most file types that are not supported by c9 editors and only make the workspace hang, such as pdf, zip, exe, etc. This small modification will allow us to also set a default of what files cloud9 should not attempt to open.

The overarching goal is to reduce the complexity of cloud9 to students/new users, in order to help them focus on familiarizing themselves with the essential (and useful for the class) aspects of the IDE.