### PR TITLE
Fixed New File bug

### DIFF
--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -385,6 +385,7 @@ define(function(require, module, exports) {
                 
                 open({
                     path: name,
+                    focus: true,
                     active: true,
                     pane: e.pane,
                     value: "",


### PR DESCRIPTION
If no tabs are open up top and you click (+) and then New File, new file doesn't currently get focus. Result is you can't immediately hit Command+S and save. Making this small modification fixes the issue.