### PR TITLE
files fix moved to editors.js

### DIFF
--- a/plugins/c9.ide.editors/editors.js
+++ b/plugins/c9.ide.editors/editors.js
@@ -1,6 +1,6 @@
 define(function(require, module, exports) {
     main.consumes = [
-        "Plugin", "menus", "ui", "settings", "dialog.alert"
+        "Plugin", "menus", "ui", "settings"
     ];
     main.provides = ["editors"];
     return main;
@@ -10,7 +10,6 @@ define(function(require, module, exports) {
         var Plugin = imports.Plugin;
         var menus = imports.menus;
         var settings = imports.settings;
-        var alert = imports["dialog.alert"].show;
         
         var extname = require("path").extname;
         var basename = require("path").basename;
@@ -72,8 +71,9 @@ define(function(require, module, exports) {
             var ext = extname(fn).substr(1).toLowerCase();
             var filename = basename(fn).toLowerCase();
 
-            if (forbiddenFormat(ext, filename))
-                return "none";
+            // Check custom user settings first for preferred editor
+            var customEditor = settings.get("user/tabs/editorTypes/@" + ext.toLowerCase());
+            if (customEditor !== undefined) return customEditor;
 
             var editor = fileExtensions[fn] && fileExtensions[fn][0]
                 || fileExtensions[filename] && fileExtensions[filename][0]
@@ -174,26 +174,6 @@ define(function(require, module, exports) {
                 });
                 return function cancel() { cancelled = true };
             }
-        }
-
-        function forbiddenFormat(ext, filename) {
-            // Obtain lst of excluded file formats
-            var lst = settings.get("user/tabs/@excludeFormats")
-                .replace(new RegExp(" ", "g"), "")
-                .toLowerCase()
-                .split(",")
-                .filter(function(n) {
-                    return (n !== "");
-                });
-                
-            // Create the tab, if not forbiden format
-            if (lst.indexOf(ext) != -1) {
-                alert("Can't open " + filename
-                    + ": file format unsupported");
-                return true;
-            }
-
-            return false;
         }
 
         /***** Lifecycle *****/

--- a/plugins/c9.ide.editors/editors.js
+++ b/plugins/c9.ide.editors/editors.js
@@ -72,7 +72,7 @@ define(function(require, module, exports) {
             var ext = extname(fn).substr(1).toLowerCase();
             var filename = basename(fn).toLowerCase();
 
-            if (forbiddenFormat(ext, filename)) {
+            if (forbiddenFormat(ext, filename))
                 return "none";
 
             var editor = fileExtensions[fn] && fileExtensions[fn][0]

--- a/plugins/c9.ide.editors/editors.js
+++ b/plugins/c9.ide.editors/editors.js
@@ -1,6 +1,6 @@
 define(function(require, module, exports) {
     main.consumes = [
-        "Plugin", "menus", "ui"
+        "Plugin", "menus", "ui", "settings", "dialog.alert"
     ];
     main.provides = ["editors"];
     return main;
@@ -9,6 +9,8 @@ define(function(require, module, exports) {
         var ui = imports.ui;
         var Plugin = imports.Plugin;
         var menus = imports.menus;
+        var settings = imports.settings;
+        var alert = imports["dialog.alert"].show;
         
         var extname = require("path").extname;
         var basename = require("path").basename;
@@ -69,11 +71,28 @@ define(function(require, module, exports) {
         function findEditorByFilename(fn) {
             var ext = extname(fn).substr(1).toLowerCase();
             var filename = basename(fn).toLowerCase();
+
+            // Obtain lst of excluded file formats
+            var lst = settings.get("user/tabs/@excludeFormats")
+                .replace(new RegExp(" ", "g"), "")
+                .toLowerCase()
+                .split(",")
+                .filter(function(n) {
+                    return (n !== "");
+                });
+
+            // Create the tab, if not forbiden format
+            if (lst.indexOf(ext) != -1) {
+                alert("Can't open " + filename 
+                    + ": file format unsupported");
+                return "none";
+            }
+
             var editor = fileExtensions[fn] && fileExtensions[fn][0]
                 || fileExtensions[filename] && fileExtensions[filename][0]
                 || fileExtensions[ext] && fileExtensions[ext][0]
                 || defaultEditor;
-            
+
             return findEditor(null, editor);
         }
         

--- a/plugins/c9.ide.editors/editors.js
+++ b/plugins/c9.ide.editors/editors.js
@@ -67,26 +67,13 @@ define(function(require, module, exports) {
                 || ~extensions.indexOf(filename)
                 || ~extensions.indexOf(ext) ? true : false;
         }
-        
+
         function findEditorByFilename(fn) {
             var ext = extname(fn).substr(1).toLowerCase();
             var filename = basename(fn).toLowerCase();
 
-            // Obtain lst of excluded file formats
-            var lst = settings.get("user/tabs/@excludeFormats")
-                .replace(new RegExp(" ", "g"), "")
-                .toLowerCase()
-                .split(",")
-                .filter(function(n) {
-                    return (n !== "");
-                });
-
-            // Create the tab, if not forbiden format
-            if (lst.indexOf(ext) != -1) {
-                alert("Can't open " + filename 
-                    + ": file format unsupported");
+            if (forbiddenFormat(ext, filename)) {
                 return "none";
-            }
 
             var editor = fileExtensions[fn] && fileExtensions[fn][0]
                 || fileExtensions[filename] && fileExtensions[filename][0]
@@ -95,7 +82,7 @@ define(function(require, module, exports) {
 
             return findEditor(null, editor);
         }
-        
+
         /***** Methods *****/
         
         function registerPlugin(type, caption, editor, extensions) {
@@ -188,7 +175,27 @@ define(function(require, module, exports) {
                 return function cancel() { cancelled = true };
             }
         }
-        
+
+        function forbiddenFormat(ext, filename) {
+            // Obtain lst of excluded file formats
+            var lst = settings.get("user/tabs/@excludeFormats")
+                .replace(new RegExp(" ", "g"), "")
+                .toLowerCase()
+                .split(",")
+                .filter(function(n) {
+                    return (n !== "");
+                });
+                
+            // Create the tab, if not forbiden format
+            if (lst.indexOf(ext) != -1) {
+                alert("Can't open " + filename
+                    + ": file format unsupported");
+                return true;
+            }
+
+            return false;
+        }
+
         /***** Lifecycle *****/
         
         plugin.on("load", function(){

--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -1077,10 +1077,14 @@ define(function(require, module, exports) {
             // if (options.document.filter === undefined)
             //     options.document.filter = true;
             options.editorType = type;
-            
+
+            // Don't proceed if findEditorByFilename returns "none"
+            if (editor === "none")
+                return;
+
             // Create the tab
             tab = createTab(options);
-            
+
             // Focus
             if (options.focus)
                 focusTab(tab, options.focus !== true);

--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -1078,9 +1078,11 @@ define(function(require, module, exports) {
             //     options.document.filter = true;
             options.editorType = type;
 
-            // Don't proceed if findEditorByFilename returns "none"
-            if (editor === "none")
-                return;
+            // Don't proceed if findEditorByFilename returned "none"
+            if (editor === "none"){
+                alert("Can't open " + basename(path) + ": file format unsupported");
+                return callback(new Error("File not supported"))
+            }
 
             // Create the tab
             tab = createTab(options);


### PR DESCRIPTION
Additional code whereby the user can specify a list of comma-separated file extensions via the user settings file, to prevent all files with those extensions from being opened.

I moved the string manipulations to editors.js and only added a return statement in tabmanager.js to prevent the tab from being created if the file is a 'forbidden format'