### PR TITLE
Change button order

### DIFF
--- a/plugins/c9.ide.dialog.common/confirm.js
+++ b/plugins/c9.ide.dialog.common/confirm.js
@@ -14,8 +14,8 @@ define(function(require, module, exports) {
             allowClose: false,
             modal: true,
             elements: [
-                { type: "button", id: "cancel", caption: "Cancel", hotkey: "ESC", onclick: function(){ plugin.hide() } },
-                { type: "button", id: "ok", caption: "OK", color: "green", "default": true, onclick: function(){ plugin.hide() } }
+                { type: "button", id: "ok", caption: "OK", color: "green", "default": true, onclick: function(){ plugin.hide() } },
+                { type: "button", id: "cancel", caption: "Cancel", hotkey: "ESC", onclick: function(){ plugin.hide() } }
             ]
         });
         

--- a/plugins/c9.ide.dialog.file/file.xml
+++ b/plugins/c9.ide.dialog.file/file.xml
@@ -68,18 +68,18 @@
                 </a:checkbox>
                 <a:filler />
                 <a:button
-                  id       = "btnCancel"
-                  class    = "btn-red"
-                  skin     = "btn-default-css3"
-                  width   = "120"
-                  caption  = "Cancel"
-                />
-                <a:button
                   id      = "btnChoose"
                   class   = "btn-green"
                   width   = "120"
                   caption = "Save"
                   skin    = "btn-default-css3"
+                />
+                <a:button
+                  id       = "btnCancel"
+                  class    = "btn-red"
+                  skin     = "btn-default-css3"
+                  width   = "120"
+                  caption  = "Cancel"
                 />
             </a:hbox>
         </a:vbox>

--- a/plugins/c9.ide.dialog.login/login.xml
+++ b/plugins/c9.ide.dialog.login/login.xml
@@ -48,15 +48,15 @@
             
             <a:hbox edge="23 0 10" pack="end" padding="8">
                 <a:button
-                  id       = "btnCancel"
-                  skin     = "btn-default-css3"
-                  caption  = "Cancel"
-                />
-                <a:button
                   id      = "btnChoose"
                   class   = "btn-green"
                   caption = "OK"
                   skin    = "btn-default-css3"
+                />
+                <a:button
+                  id       = "btnCancel"
+                  skin     = "btn-default-css3"
+                  caption  = "Cancel"
                 />
             </a:hbox>
         </a:vbox>


### PR DESCRIPTION
As discussed at https://groups.google.com/forum/#!topic/cloud9-sdk/4RjhLP1M5go, I have swapped the OK/cancel buttons on the following dialogs:

- File chooser
- Confirm dialog
- Login dialog

This is to be consistent with other dialogs in the IDE, such as the Unsaved Changes dialog and the Confirm Remove dialog.
