### PR TITLE
editorTypes

### DIFF
--- a/plugins/c9.ide.editors/editors.js
+++ b/plugins/c9.ide.editors/editors.js
@@ -1,6 +1,6 @@
 define(function(require, module, exports) {
     main.consumes = [
-        "Plugin", "menus", "ui"
+        "Plugin", "menus", "ui", "settings"
     ];
     main.provides = ["editors"];
     return main;
@@ -9,6 +9,7 @@ define(function(require, module, exports) {
         var ui = imports.ui;
         var Plugin = imports.Plugin;
         var menus = imports.menus;
+        var settings = imports.settings;
         
         var extname = require("path").extname;
         var basename = require("path").basename;
@@ -65,18 +66,23 @@ define(function(require, module, exports) {
                 || ~extensions.indexOf(filename)
                 || ~extensions.indexOf(ext) ? true : false;
         }
-        
+
         function findEditorByFilename(fn) {
             var ext = extname(fn).substr(1).toLowerCase();
             var filename = basename(fn).toLowerCase();
+
+            // Check custom user settings first for preferred editor
+            var customEditor = settings.get("user/tabs/editorTypes/@" + ext.toLowerCase());
+            if (customEditor !== undefined) return customEditor;
+
             var editor = fileExtensions[fn] && fileExtensions[fn][0]
                 || fileExtensions[filename] && fileExtensions[filename][0]
                 || fileExtensions[ext] && fileExtensions[ext][0]
                 || defaultEditor;
-            
+
             return findEditor(null, editor);
         }
-        
+
         /***** Methods *****/
         
         function registerPlugin(type, caption, editor, extensions) {
@@ -169,7 +175,7 @@ define(function(require, module, exports) {
                 return function cancel() { cancelled = true };
             }
         }
-        
+
         /***** Lifecycle *****/
         
         plugin.on("load", function(){

--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -1077,10 +1077,16 @@ define(function(require, module, exports) {
             // if (options.document.filter === undefined)
             //     options.document.filter = true;
             options.editorType = type;
-            
+
+            // Don't proceed if findEditorByFilename returned "none"
+            if (editor === "none"){
+                alert("Can't open " + basename(path) + ": file format unsupported");
+                return callback(new Error("File not supported"))
+            }
+
             // Create the tab
             tab = createTab(options);
-            
+
             // Focus
             if (options.focus)
                 focusTab(tab, options.focus !== true);

--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -1079,9 +1079,9 @@ define(function(require, module, exports) {
             options.editorType = type;
 
             // Don't proceed if findEditorByFilename returned "none"
-            if (editor === "none"){
+            if (editor === "none") {
                 alert("Can't open " + basename(path) + ": file format unsupported");
-                return callback(new Error("File not supported"))
+                return callback(new Error("File not supported"));
             }
 
             // Create the tab


### PR DESCRIPTION
New version whereby:
1) Alert stays in tabmanager.js
2) Open calls it's callback with an error message when cancelling 
3) The formats are now stored as a json object in user/tabs/editorTypes, providing a mapping between formats and editors. Any custom choice of editor in the settings now takes precedence over the default editor