### PR TITLE
fixes CSS for some elements

### DIFF
--- a/plugins/c9.ide.layout.classic/less/c9-toolbarbutton-glossy.less
+++ b/plugins/c9.ide.layout.classic/less/c9-toolbarbutton-glossy.less
@@ -12,12 +12,6 @@
     .box-shadow(~"inset 1px 1px @{button-glossy-hover-shadow-color}, inset -1px -1px @{button-glossy-hover-shadow-color}");
     text-shadow: @button-glossy-hover-text-shadow;
 }
-.c9-toolbarbutton-glossyDown, .c9-toolbarbutton-glossyActive {
-    border: 1px solid @button-glossy-active-border-color;
-    .gradient(~"linear-gradient(top, @{button-glossy-active-background-1} 0%, @{button-glossy-active-background-2} 55%, @{button-glossy-active-background-3} 55%, @{button-glossy-active-background-4} 100%)");
-    .box-shadow(~"inset 1px 1px @{button-glossy-active-shadow-color}, inset -1px -1px @{button-glossy-active-shadow-color}");
-    text-shadow: @button-glossy-active-text-shadow;
-}
 .c9-toolbarbutton-glossyDisabled{
     color : @button-glossy-disabled-color;
     text-shadow : @button-glossy-disabled-text-shadow;

--- a/plugins/c9.ide.layout.classic/themes/default-flat-dark.less
+++ b/plugins/c9.ide.layout.classic/themes/default-flat-dark.less
@@ -730,7 +730,7 @@
 @breakpoint-list-item-border-top: transparent;
 @breakpoint-list-item-padding: 1px 10px 0 7px;
 @breakpoint-list-item-hover-color: darken(#e0e3e8, @darken-chrome);
-@breakpoint-list-item-hover-background: darken(#F6F6F6, @darken-chrome);
+@breakpoint-list-item-hover-background: darken(#252525, @darken-chrome);
 @breakpoint-list-item-hover-border-top: transparent;
 
 // Breakpoint Condition Dialog
@@ -774,7 +774,7 @@
 @immediate-font-smoothing: false;
 
 @immediate-dark-row-border-color: darken(rgb(29, 28, 28), @darken-chrome);
-@immediate-dark-return: darken(#252525, @darken-chrome);
+@immediate-dark-return: darken(#FFFFFF, @darken-chrome);
 @immediate-dark-warn: yellow;
 @immediate-dark-error: red;
 @immediate-dark-property: darken(#BEDB18, @darken-chrome);

--- a/plugins/c9.ide.layout.classic/themes/flat-dark.less
+++ b/plugins/c9.ide.layout.classic/themes/flat-dark.less
@@ -5,9 +5,10 @@
 }
 
 .bartools .c9-toolbarbutton-glossymenuDown{
-    background-color: #ffffff;
+    background-color: #494949;
     box-shadow: 0px 3px 15px 0px rgba(0, 0, 0, 0.29);
-    border: 1px solid #dedede;
+    border-left: 1px solid #252525;
+    border-right: 1px solid #252525;
 }
 
 .output .toolbar .c9-toolbarbutton-glossyOver{


### PR DESCRIPTION
![preview-active-old](https://cloud.githubusercontent.com/assets/7230211/16715291/cca6f352-46db-11e6-8aa8-76328431427c.png)
![run-active-old](https://cloud.githubusercontent.com/assets/7230211/16715292/ccb4f5a6-46db-11e6-91b1-efb9bf1e325f.png)
![breakpoint-keyword-hover-old](https://cloud.githubusercontent.com/assets/7230211/16715288/cbe4f66c-46db-11e6-8430-e0efa731bba6.png)
![breakpoints-hover-old](https://cloud.githubusercontent.com/assets/7230211/16715290/cc10785a-46db-11e6-9c6e-1ca4bafe0a3f.png)

* fixes acitve background colors for "Run" and "Preview" buttons.
* fixes hover background color for breakpoints in "Breakpoints" panel.
* fixes color for box showing when hovering keywords while debugging.

![preview-active-new](https://cloud.githubusercontent.com/assets/7230211/16715293/cd3f62e0-46db-11e6-95f1-0254962909c4.png)
![breakpoint-keyword-hover-new](https://cloud.githubusercontent.com/assets/7230211/16715287/cb856986-46db-11e6-81ce-cc25278919ca.png)
![breakpoints-hover-new](https://cloud.githubusercontent.com/assets/7230211/16715289/cbf8126a-46db-11e6-9996-fef3cfcd758e.png)


