### PR TITLE
Set Scroller Height to a multiple of Line Height

### DIFF
--- a/plugins/c9.ide.terminal/terminal.js
+++ b/plugins/c9.ide.terminal/terminal.js
@@ -888,6 +888,12 @@ define(function(require, exports, module) {
 
                     // top 1px is for cursor outline
                     var rows = Math.floor((h - 1) / config.lineHeight);
+
+                    // sets scrollerHeight to be a multiple of the lineHeight + 1px for padding
+                    if ((h - 1) % config.lineHeight !== 0){
+                        size.scrollerHeight = rows * config.lineHeight + 1;
+                    }
+
                     if (rows <= 2 && !ace.renderer.scrollBarV.isVisible)
                         w -= ace.renderer.scrollBarV.width;
                     var cols = Math.floor(w / config.characterWidth);


### PR DESCRIPTION
Previously, we've had a minor issue where the terminal could have a partial line (as below):

![screen shot 2016-07-27 at 11 10 40 am](https://cloud.githubusercontent.com/assets/7552511/17180604/0b8cd1ba-53eb-11e6-802b-f5a66b22de05.png)

And when going to clear the terminal using Ctrl-L, the partial line would still be present (as below):

![screen shot 2016-07-27 at 11 10 55 am](https://cloud.githubusercontent.com/assets/7552511/17180695/45c3abec-53eb-11e6-9bdf-bb6b616d1e80.png)

Per this PR, this will set the scroller height to be a multiple of the line height (+ 1 px for padding) so this will prevent the above issue.
