### PR TITLE
Timeslider close icon was missing for light theme, it's fixed.

### DIFF
--- a/plugins/c9.ide.layout.classic/themes/default-flat-light.less
+++ b/plugins/c9.ide.layout.classic/themes/default-flat-light.less
@@ -328,7 +328,7 @@
 @time-slider-revert-active-gradient: linear-gradient(top, #98c878 0%, #98c878 100%);
 @time-slider-revert-active-padding: @time-slider-revert-padding;
 
-@time-slider-close-image: "@{image-path}/close_tab_btn_flat_light.png";
+@time-slider-close-image: "@{image-path}/close_tab_btn.png";
 @time-slider-close-image-width: 42px;
 @time-slider-close-image-height: 28px;
 @time-slider-close-idle-position: 0 0;


### PR DESCRIPTION
- Before fix 

![before](https://cloud.githubusercontent.com/assets/13097409/18092084/98b5e1dc-6ed3-11e6-9ee3-258ba020d2b8.png)

- After fix

![After fix](https://cloud.githubusercontent.com/assets/13097409/18091982/42e59eaa-6ed3-11e6-840d-061a11d9a71c.png)