### PR TITLE
Correct retina icons on a forked debugger plugin

### DIFF
--- a/plugins/c9.ide.layout.classic/less/c9-menu-btn.less
+++ b/plugins/c9.ide.layout.classic/less/c9-menu-btn.less
@@ -65,7 +65,7 @@
     display: none;
 }
 
-.c9-menu-btn.nosize .icon { background-size: auto !important; }
+.c9-menu-btn.nosize .icon { background-size: auto; }
 
 .c9-menu-btn.preferences{
     padding: @preference-menu-button-padding !important;


### PR DESCRIPTION
When a custom debugger plugin is used, order of the css compilation changes and causing wrong display on a forked debugger with retina display.
<img width="344" alt="screen shot 2016-09-06 at 00 22 12" src="https://cloud.githubusercontent.com/assets/7248325/18257177/631f275a-73c8-11e6-943e-26c2adb00980.png">

Removing this important flag solves the issue.
I have not seen any side effects of removing this important flag