### PR TITLE
Allow plugins that modify Ace to extend session state

### DIFF
--- a/plugins/c9.ide.ace/ace.js
+++ b/plugins/c9.ide.ace/ace.js
@@ -2001,6 +2001,13 @@ define(function(require, exports, module) {
                     state: session.bgTokenizer.states[row - 1],
                     mode: session.$mode.$id
                 };
+
+                state.extensionData = {};
+
+                // Any additional state given by ace extensions
+                for (key in dataExtensionHandlers) {
+                    state.extensionData[key] = dataExtensionHandlers[key].getState(session, doc);
+                }
             }
             
             function setState(doc, state) {
@@ -2086,6 +2093,11 @@ define(function(require, exports, module) {
                     
                     ace.on("changeSession", listen);
                     session.on("unload", clean);
+                }
+
+                // Any additional state given by ace extensions
+                for (key in dataExtensionHandlers) {
+                    dataExtensionHandlers[key].setState(state.extensionData[key]);
                 }
             }
             
@@ -2739,6 +2751,24 @@ define(function(require, exports, module) {
              * @param {Number}   [state.jump.select.column]             The column to select to (0 based)
              */
             plugin.freezePublicAPI({
+                /*
+                 * Register a data extension handler, which will add
+                 * extra information to a serialized Ace editor session,
+                 * for plugins that modify the Ace editor.
+                 */
+                addDataExtensionHandler: function(name, getState, setState) {
+                    if (name in dataExtensionHandlers) {
+                        return false;
+                    }
+                    else {
+                        dataExtensionHandlers[name] = {
+                            getState: getState,
+                            setState: setState
+                        }
+                        return true;
+                    }
+                },
+
                 /**
                  * @ignore
                  */


### PR DESCRIPTION
Some plugins (like Droplet for CS50) are not Editor plugins, but instead modify existing Ace instances to change the editor experience. This change allows such plugins to add extra information to the persistent session information serialized in `getState()` and `setState()` for Ace editors. It exposes one new public API method for the Ace plugin:
```
function extendSerializedState(serialize, deserialize)
```
where `serialize(session) -> state` is a function taking an Ace editor session and returning a persistable object, and `deserialize(state, session) -> void` is a function taking that persistable object and an Ace session, and modifying the session to reflect the object.