### PR TITLE
Fix for undefined error log in console

### DIFF
--- a/plugins/c9.error/error_handler.js
+++ b/plugins/c9.error/error_handler.js
@@ -115,7 +115,7 @@ function plugin(options, imports, register) {
         var accept = req.headers.accept || '';
 
         if (statusCode == 500) {
-            console.error(err && err.stack);
+            console.error(err && (err.stack || err));
             emitter.emit("internalServerError", {
                 err: err,
                 req: req


### PR DESCRIPTION
When css|less build fails it is logging as undefined in console.
In that case err object does not have any stack property.
Printing the error itself in that case will be sufficient.