### PR TITLE
drops buggy and redundant afterRmdir handler

### DIFF
--- a/plugins/c9.ide.editors/tabmanager.js
+++ b/plugins/c9.ide.editors/tabmanager.js
@@ -138,14 +138,7 @@ define(function(require, module, exports) {
             }
             fs.on("afterUnlink", removeTab);
             fs.on("afterRmfile", removeTab);
-            fs.on("afterRmdir", function(e) {
-                var path = e.path;
-                Object.keys(tabs).forEach(function(id) {
-                    var tab = tabs[id];
-                    if (tab.path && tab.path.indexOf(path) === 0)
-                        tab.unload();
-                });
-            });
+
             // Close a pane when it doesn't open
             // @todo this should probably be interactive (unless during init)
             // @todo move this to tabbehaviours?


### PR DESCRIPTION
Deleting a directory causes [afterRmdir](https://github.com/c9/core/blob/106832d7b6f5f10fd83553db34e84c6478b42af3/plugins/c9.ide.editors/tabmanager.js#L141)'s handler to be fired, and
therefore unloading tabs whose paths start with the directory's
path, mistakenly considering the files open in such tabs to be under
that directory.

There are cases where a tab's path starts with the directory's path,
and yet the file is not under the directory (e.g., `/foo.c` and `/foo`),
so this causes tabs to be closed and unloaded when they shouldn't.

This could be easily solved, except that there's a race condition
caused when the watcher.gui plugin [asks](https://github.com/c9/core/blob/master/plugins/c9.ide.watcher/gui.js#L507) the user, possibly too late,
whether to keep the tab of a deleted file open.

By removing this handler, the tab is [closed and unloaded](https://github.com/c9/core/blob/master/plugins/c9.ide.watcher/gui.js#L574), only if the
user doesn't want to keep it open.

![afterrmdir](https://cloud.githubusercontent.com/assets/7230211/21526414/abcbebd8-cd2c-11e6-9b00-0d38b7151122.gif)