### PR TITLE
makes dialog's esc handler handle esc only

### DIFF
--- a/plugins/c9.ide.dialog/dialog.js
+++ b/plugins/c9.ide.dialog/dialog.js
@@ -133,9 +133,9 @@ define(function(require, module, exports) {
                     emit("resize");
                 });
                 var escHandler = function(e) {
-                    if (dialog.visible) {
+                    if (dialog.visible && e.keyCode == 27) {
                         dialog.dispatchEvent("keydown", e);
-                        if (e.keyCode == 27) e.stopPropagation();
+                        e.stopPropagation();
                     }
                 };
                 var addEscHandler = function() {


### PR DESCRIPTION
Proposes a fix for https://github.com/c9/core/commit/31ab6ca2ac7b422a6284e99ff3517b783fdc5ba4#commitcomment-21382067!

cc @nightwing 