### PR TITLE
Allow Markdown outlining to show levels beyond level 2.

### DIFF
--- a/plugins/c9.ide.language.jsonalyzer/worker/handlers/jsonalyzer_md.js
+++ b/plugins/c9.ide.language.jsonalyzer/worker/handlers/jsonalyzer_md.js
@@ -13,10 +13,16 @@ var ctagsUtil = require("plugins/c9.ide.language.jsonalyzer/worker/ctags/ctags_u
 var TAGS = [
     { regex: /(?:^|\n)# (.*?)[#\s]*(?:\n|$)/g, kind: "property" },
     { regex: /(?:^|\n)([A-Za-z0-9].*?)\s*\n={2,}(?:\n|$)/g, kind: "property" },
-    { regex: /(?:^|\n)#{3,} (.*?)[#\s]*(?:\n|$)/g, kind: "property2", indent: 2 },
-    { regex: /(?:^|\n)([A-Za-z0-9].*?)\s*\n-{3,}(?:\n|$)/g, kind: "property2", indent: 2 },
     { regex: /(?:^|\n)#{2} (.*?)[#\s]*(?:\n|$)/g, kind: "property2", indent: 1 },
     { regex: /(?:^|\n)([A-Za-z0-9].*?)\s*\n-{2}(?:\n|$)/g, kind: "property2", indent: 1 },
+    { regex: /(?:^|\n)#{3} (.*?)[#\s]*(?:\n|$)/g, kind: "property2", indent: 2 },
+    { regex: /(?:^|\n)([A-Za-z0-9].*?)\s*\n-{3,}(?:\n|$)/g, kind: "property2", indent: 2 },
+    { regex: /(?:^|\n)#{4} (.*?)[#\s]*(?:\n|$)/g, kind: "property2", indent: 3 },
+    { regex: /(?:^|\n)([A-Za-z0-9].*?)\s*\n-{4,}(?:\n|$)/g, kind: "property2", indent: 3 },
+    { regex: /(?:^|\n)#{5} (.*?)[#\s]*(?:\n|$)/g, kind: "property2", indent: 4 },
+    { regex: /(?:^|\n)([A-Za-z0-9].*?)\s*\n-{5,}(?:\n|$)/g, kind: "property2", indent: 4 },
+    { regex: /(?:^|\n)#{6} (.*?)[#\s]*(?:\n|$)/g, kind: "property2", indent: 5 },
+    { regex: /(?:^|\n)([A-Za-z0-9].*?)\s*\n-{6,}(?:\n|$)/g, kind: "property2", indent: 5 },
 ];
 var GUESS_FARGS = false;
 var EXTRACT_DOCS = false;
@@ -30,10 +36,10 @@ handler.extensions = ["md", "markdown"];
 handler.analyzeCurrent = function(path, doc, ast, options, callback) {
     if (doc === "")
         return callback(null, {});
-        
+
     if (doc.length > jsonalyzer.getMaxFileSizeSupported())
         return callback(null, {});
-    
+
     var results = {};
     TAGS.forEach(function(tag) {
         if (tag.kind === "import")


### PR DESCRIPTION
Fixes #426 using a "more regexes" approach. With this fix, the outline now looks like this:

```markdown
# Level 1

## Level 2

### Level 3

#### Level 4

##### Level 5

###### Level 6
```

![image](https://cloud.githubusercontent.com/assets/6859247/26612485/b548f60e-45e7-11e7-83aa-9ee10a6c3087.png)