### PR TITLE
[plugins.c9.vfs.standalone] use current hostname for preview vfs-target

### DIFF
--- a/plugins/c9.vfs.standalone/standalone.js
+++ b/plugins/c9.vfs.standalone/standalone.js
@@ -142,7 +142,7 @@ function plugin(options, imports, register) {
         },
         previewHandler.getProxyUrl(function() {
             return {
-                url: "http://localhost:" + options.options.port + "/vfs"
+                url: "http://" + options.options.host + ":" + options.options.port + "/vfs"
             };
         }),
         previewHandler.proxyCall()


### PR DESCRIPTION
Running c9 in `standalone` mode on a remote Host or different IP blocks the _Preview_-feature for document-types other than markdown:
```
{"error":{"code":500,"scope":"standalone","message":"connect ECONNREFUSED"}}
```

The source of this problem is the hardcoded hostname in the `/preview` api-endpoint: `localhost`.

This PR resolves the problem in using the actual host instead of `localhost`.