### PR TITLE
Fix IKPdb netproxy.js to support aws-sam-local / docker startup time.

### DIFF
--- a/plugins/c9.ide.run.debug.ikpdb/netproxy.js
+++ b/plugins/c9.ide.run.debug.ikpdb/netproxy.js
@@ -13,7 +13,7 @@ var browserBuffer = [];
 var browserClient, 
     debugClient;
 
-var MAX_RETRIES = 100;
+var MAX_RETRIES = 600;
 var RETRY_INTERVAL = 300;
 
 var log = console.log;


### PR DESCRIPTION
FIX: Tuning IKPdb netproxy.js MAX_RETRIES to support aws-sam-local / docker startup time.