### PR TITLE
Changed from git:// to https:// in Readme for Cloning 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ https://groups.google.com/forum/#!forum/cloud9-sdk
 
 Follow these steps to install the SDK:
 
-    git clone git://github.com/c9/core.git c9sdk
+    git clone https://github.com/c9/core.git c9sdk
     cd c9sdk
     scripts/install-sdk.sh
     


### PR DESCRIPTION
Changed from git:// to https:// in **Readme** for Cloning 

`git clone git://github.com/c9/core.git c9sdk`

to

`git clone https://github.com/c9/core.git c9sdk`