### PR TITLE
Set socket.emit

### DIFF
--- a/plugins/c9.ide.run.debug/debuggers/chrome/chrome-debug-proxy-launcher.js
+++ b/plugins/c9.ide.run.debug/debuggers/chrome/chrome-debug-proxy-launcher.js
@@ -124,7 +124,6 @@ define(function(require, exports, module) {
         
         var stream;
         var socket = options.socket;
-        socket.emit = socket.getEmitter();
         socket.send = function(s) {
             stream && stream.write(JSON.stringify(s) + "\0");
         };

--- a/plugins/c9.ide.run.debug/debuggers/socket.js
+++ b/plugins/c9.ide.run.debug/debuggers/socket.js
@@ -24,8 +24,10 @@ define(function(require, exports, module) {
             var emit = socket.getEmitter();
             var state, stream, connected, away;
             
-            if (proxy == false)
+            if (proxy == false) {
+                socket.emit = socket.getEmitter();
                 return socket;
+            }
             
             if (typeof proxy == "string")
                 proxy = { source: proxy };
@@ -260,7 +262,12 @@ define(function(require, exports, module) {
                 /**
                  * 
                  */
-                send: send
+                send: send,
+                
+                /**
+                 * 
+                 */
+                emit: socket.getEmitter()
             });
             
             socket.load("socket" + counter++);


### PR DESCRIPTION
When a custom proxy is used, in socket.js freezePublicAPI method is run. That's why, in 