### PR TITLE
Fix issue #496: Cannot set headers after they are sent to the client

### DIFF
--- a/plugins/c9.vfs.server/vfs.server.js
+++ b/plugins/c9.vfs.server/vfs.server.js
@@ -138,7 +138,8 @@ function plugin(options, imports, register) {
             req.on("close", function() {
                 done = true;
                 cancel();
-                res.json({}, 0, 500);
+                if(!res.headersSent)
+                    res.json({}, 0, 500);
             });
         }
     ]);


### PR DESCRIPTION
On newer versions of Node.js (>10.1.0), cloud9 init failed because an attempt to send an already sent response on plugin vfs. More info in the issue description.

*Issue #, if available:* [496](https://github.com/c9/core/issues/496#issuecomment-403581681)

*Description of changes:* Check response.headersSent before attempting to send a response on vfs close. That property exists in Node.js since v0.9.3, so it should be backwards compatible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
