### PR TITLE
added linkMenuCreated event to link_handler

### DIFF
--- a/plugins/c9.ide.terminal/link_handler.js
+++ b/plugins/c9.ide.terminal/link_handler.js
@@ -30,6 +30,7 @@ define(function(require, exports, module) {
         var BASEPATH = options.previewUrl;
         
         var plugin = new Plugin("Ajax.org", main.consumes);
+        const emit = plugin.getEmitter();
         var menuPath, lastLink;
         
         var reHome = new RegExp("^" + util.escapeRegExp(c9.home));
@@ -135,6 +136,8 @@ define(function(require, exports, module) {
                         commands.exec("copy", null, { data: lastLink.value });
                 }
             }, plugin);
+
+            emit("linkMenuCreated", {menu: menuLink});
         }
             
         /***** Methods *****/
@@ -282,6 +285,16 @@ define(function(require, exports, module) {
         /***** Lifecycle *****/
         
         plugin.freezePublicAPI({
+            _events: [
+                /**
+                 * Fires after a new link menu is created.
+                 *
+                 * @event linkMenuCreated
+                 * @param {Object} e
+                 * @param {MenuItem} e.menu the newly created link menu.
+                 */
+                "linkMenuCreated"
+            ],
             open: open
         });
         


### PR DESCRIPTION
*Description of changes:*
Adds `linkMenuCreated` event that gets fired right after a new link menu is created to allow other plugins to hook into it and get an instance of the newly created link menu and customize it. One use case that we have is removing the **Open In Preview** menu item just to simplify the user interface for students since we don't use any previewers and right now there's no clean way to access this menu.

![screenshot from 2018-08-20 21-01-06](https://user-images.githubusercontent.com/7230211/44375862-c8d85980-a4c3-11e8-9e8a-1f678d1c464b.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

cc @dmalan 
