### PR TITLE
fixed console resizing bug

### DIFF
--- a/plugins/c9.ide.console/console.js
+++ b/plugins/c9.ide.console/console.js
@@ -147,7 +147,7 @@ define(function(require, module, exports) {
             // Track splitter and update state
             var splitter = consoleRow.$handle;
             splitter && splitter.on("dragdrop", function(e) {
-                height = Math.max(minHeight, container.height);
+                height = Math.max(minHeight, container.$ext.offsetHeight);
                 if (height)
                     settings.set("state/console/@height", height);
                 emit("resize");


### PR DESCRIPTION
*Issue #, if available:*
When resizing console, maximizing it, then minimizing it again, the draggable bar is no longer at the correct height so trying to resize the console by dragging the bar no longer works. (See the gif below!) This happens because `container.height` becomes a string that represents the percentage height (e.g., `"50%"`) and later `Math.max` is called with an integer and that string, returning `NaN` to which the container's height is incorrectly set.

![console](https://user-images.githubusercontent.com/7230211/46570780-ccbb2080-c937-11e8-8051-672cdeb66c6e.gif)


*Description of changes:*
This PR uses the container's `offsetHeight` instead.

cc @danallan @nightwing 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
