### PR TITLE
Updated to include --afile in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following options can be used:
     -k               Kill tmux server in test mode
     -b               Start the bridge server - to receive commands from the cli  [default: false]
     -w               Workspace directory
+    -afile           Basic authentication file with multiple users
     --port           Port
     --debug          Turn debugging on
     --listen         IP address of the server


### PR DESCRIPTION
Will also need some information on how afile works.

*Issue*
-afile command not in README despite commit including it in December. Was looking around ages for this so having it in the README would help. 

*Description of changes:*
Added it to README

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.