### PR TITLE
clear the gdb error message

### DIFF
--- a/plugins/c9.ide.run.debug/debuggers/gdb/shim.js
+++ b/plugins/c9.ide.run.debug/debuggers/gdb/shim.js
@@ -653,7 +653,7 @@ function GDB() {
         this.proc.on("error", function(e) {
             console.error("ERROR while launching the debugger:");
             if (e.code == "ENOENT") {
-                console.log("\t\"gdbserver\" is not installed");
+                console.log("\t\"gdb\" is not installed");
             } else {
                 console.error(e);
             }


### PR DESCRIPTION
*Issue #, if available:*

C9 reminds me `"gdbserver" is not installed` while I do install gdbserver and link it to `/usr/bin/gdbserver`.
Then I check the `c9gdbshim.js ` and finally find what I actually forgot to install is `gdb` instead of `gdbserver`, C9 show a wrong error message.

*Description of changes:*
shim.js 
line 656: `console.log("\t\"gdbserver\" is not installed");` ➡ `console.log("\t\"gdb\" is not installed");`



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
