### PR TITLE
Golang Autocompletion

### DIFF
--- a/plugins/c9.ide.language.go/README.md
+++ b/plugins/c9.ide.language.go/README.md
@@ -14,6 +14,11 @@ for an overview of the APIs and techniques used in this plugin.
 This plugin is still marked "experimental". To use it in Cloud9,
 please go to Cloud9 > Preferences > Experimental > Go Code Completion.
 
+Make sure that go and gocode are installed on your path
+sudo apt install go
+go get github.com/stamblerre/gocode
+
 ## License
 
 MIT
+

--- a/plugins/c9.ide.language.go/worker/go_completer.js
+++ b/plugins/c9.ide.language.go/worker/go_completer.js
@@ -65,11 +65,11 @@ handler.complete = function(doc, fullAst, pos, options, callback) {
         
         var start = Date.now();
         workerUtil.execAnalysis(
-            "bash", // TODO: don't use bash here, better GOPATH handling
+            "bash", // TODO: don't use bash here
             {
                 args: [
                     "-c",
-                    "GOPATH=$HOME/.c9/gocode:$GOPATH ~/.c9/gocode/bin/gocode -f=json autocomplete " + getOffset(doc, pos)
+                    "gocode -f=json autocomplete " + getOffset(doc, pos)
                 ],
                 mode: "stdin",
                 json: true,
@@ -158,8 +158,8 @@ function ensureDaemon(callback) {
         "bash",
         {
             args: [
-                // TODO: cleanup install procedure
-                "-c", "mkdir -p ~/.c9/gocode; GOPATH=$HOME/.c9/gocode go get -u github.com/nsf/gocode && ~/.c9/gocode/bin/gocode"
+                // TODO: install procedure
+                "-c", "gocode"
             ]
         },
         function(err, child) {
@@ -185,7 +185,7 @@ function ensureDaemon(callback) {
         if (err) {
             daemon.err = err;
             if (err.code !== "ELOADING")
-                workerUtil.showError("Could not setup or start Go completion daemon. Please reload to try again.");
+                workerUtil.showError("Could not setup or start Go completion daemon. Make sure go and gocode are installed on your path, and reload to try again.");
             return callback(err);
         }
         callback();


### PR DESCRIPTION
The (experimental?) golang autocompletion was not installing correctly, and using github.com/nsf/gocode which is not currently maintained. This change requires that you install gocode independently (github.com/stamblerre/gocode is now suggested in the readme).

### *Description of changes:*
- run daemon from $PATH instead of absolute path
- remove broken installer

---

- [x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
